### PR TITLE
Add support for unix socket database connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "esbuild": "^0.19.8",
     "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
-    "ts-jest": "^29.1.1",
     "prettier": "^3.1.1",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.3.2"
   },
   "dependencies": {
@@ -44,6 +44,7 @@
     "drizzle-zod": "^0.5.1",
     "express": "^4.18.2",
     "iron-session": "^6.3.1",
+    "pg-connection-string": "^2.6.2",
     "postgres": "^3.4.3",
     "zod": "^3.22.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   iron-session:
     specifier: ^6.3.1
     version: 6.3.1(express@4.18.2)
+  pg-connection-string:
+    specifier: ^2.6.2
+    version: 2.6.2
   postgres:
     specifier: ^3.4.3
     version: 3.4.3
@@ -4354,6 +4357,10 @@ packages:
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: false
+
+  /pg-connection-string@2.6.2:
+    resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
     dev: false
 
   /picocolors@1.0.0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ async function main() {
   // setup
   const envVariables = environmentVariables.parse(process.env);
   const connectionConfig = pgConnectionString.parse(envVariables.DB_CONNECTION_URL);
-  console.log({ connectionConfig });
   const sql = postgres({
     host: connectionConfig.host ?? undefined,
     port: connectionConfig.port ? parseInt(connectionConfig.port) : undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,6 @@ async function main() {
     user: connectionConfig.user,
     password: connectionConfig.password,
     database: connectionConfig.database ?? undefined,
-    // NOTE: casting this to undefined since pg-connection-string allows for
-    // more types than postgres driver.
     ssl: connectionConfig.ssl as undefined,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
+import pgConnectionString from 'pg-connection-string';
 import { default as express } from 'express';
 import { environmentVariables } from './types';
 import * as db from './db';
@@ -16,7 +17,19 @@ async function runMigrations(dbUrl: string) {
 async function main() {
   // setup
   const envVariables = environmentVariables.parse(process.env);
-  const sql = postgres(envVariables.DB_CONNECTION_URL);
+  const connectionConfig = pgConnectionString.parse(envVariables.DB_CONNECTION_URL);
+  console.log({ connectionConfig });
+  const sql = postgres({
+    host: connectionConfig.host ?? undefined,
+    port: connectionConfig.port ? parseInt(connectionConfig.port) : undefined,
+    user: connectionConfig.user,
+    password: connectionConfig.password,
+    database: connectionConfig.database ?? undefined,
+    // NOTE: casting this to undefined since pg-connection-string allows for
+    // more types than postgres driver.
+    ssl: connectionConfig.ssl as undefined,
+  });
+
   const dbPool = drizzle(sql, { schema: db });
 
   // run


### PR DESCRIPTION
### why?
we will be using unix socket connections from cloud run to cloud sql

the urls look like this: postgres://user:password@/database?host=/cloudsql/<project-name>:<region>:<db-name>

related issue in the past https://github.com/porsager/postgres/issues/484