### PR TITLE
Add users to groups and tests for usersToGroups service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. [routers](./src/routers/) contains all the api routers which map urls to the service.
 3. [services](./src/services/) contains all business logic for the routes.
 4. [middleware](./src/middleware/) contains all the middleware that is used in the routers before the code reaches the service.
-5. [modules](./src/modules/) contains all voting models implemented in the forum backend. 
+5. [modules](./src/modules/) contains all voting models implemented in the forum backend.
 6. [types](./src/types/) contains all the zod types that are needed for validation.
 
 ## For developers
@@ -17,3 +17,7 @@
 4. update .env with connection string `postgresql://postgres:secretpassword@localhost:5432`
 5. pnpm i
 6. pnpm dev
+
+### unit testing
+
+- expects a database to be available at `postgresql://postgres:secretpassword@localhost:5432`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,22 @@
-import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
-import postgres from 'postgres';
-import pgConnectionString from 'pg-connection-string';
 import { default as express } from 'express';
 import { environmentVariables } from './types';
-import * as db from './db';
 import { apiRouter } from './routers/api';
+import { createDbPool } from './utils/createDbPool';
+import { z } from 'zod';
 const app = express();
 
-async function runMigrations(options: postgres.Options<{}> | undefined) {
-  const sql = postgres({ ...options, max: 1 });
-  const db = drizzle(sql);
-  await migrate(db, { migrationsFolder: 'migrations' });
+async function runMigrations(envVariables: z.infer<typeof environmentVariables>) {
+  const { dbPool } = createDbPool(envVariables.DB_CONNECTION_URL, { max: 1 });
+  await migrate(dbPool, { migrationsFolder: 'migrations' });
 }
 
 async function main() {
   // setup
   const envVariables = environmentVariables.parse(process.env);
-  const connectionConfig = pgConnectionString.parse(envVariables.DB_CONNECTION_URL);
-  const connectionOptions: postgres.Options<{}> | undefined = {
-    host: connectionConfig.host ?? undefined,
-    port: connectionConfig.port ? parseInt(connectionConfig.port) : undefined,
-    user: connectionConfig.user,
-    password: connectionConfig.password,
-    database: connectionConfig.database ?? undefined,
-    ssl: connectionConfig.ssl as undefined,
-  };
-  const sql = postgres(connectionOptions);
-  const dbPool = drizzle(sql, { schema: db });
+  const { dbPool } = createDbPool(envVariables.DB_CONNECTION_URL, {});
   // run migrations
-  await runMigrations(connectionOptions);
+  await runMigrations(envVariables);
   app.use('/api', apiRouter({ dbPool }));
   app.listen(
     !isNaN(Number(envVariables.PORT)) ? Number(envVariables.PORT) : 8080,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { createDbPool } from './utils/createDbPool';
 import { z } from 'zod';
 const app = express();
 
-async function runMigrations(envVariables: z.infer<typeof environmentVariables>) {
-  const { dbPool } = createDbPool(envVariables.DB_CONNECTION_URL, { max: 1 });
+async function runMigrations(dbConnectionUrl: string) {
+  const { dbPool } = createDbPool(dbConnectionUrl, { max: 1 });
   await migrate(dbPool, { migrationsFolder: 'migrations' });
 }
 
@@ -16,7 +16,7 @@ async function main() {
   const envVariables = environmentVariables.parse(process.env);
   const { dbPool } = createDbPool(envVariables.DB_CONNECTION_URL, {});
   // run migrations
-  await runMigrations(envVariables);
+  await runMigrations(envVariables.DB_CONNECTION_URL);
   app.use('/api', apiRouter({ dbPool }));
   app.listen(
     !isNaN(Number(envVariables.PORT)) ? Number(envVariables.PORT) : 8080,

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -41,6 +41,11 @@ export function getRegistration(dbPool: PostgresJsDatabase<typeof db>) {
       where: eq(db.registrations.userId, userId),
     });
 
-    return res.json({ data: registration });
+    const usersToGroups = await dbPool.query.usersToGroups.findMany({
+      where: eq(db.usersToGroups.userId, userId),
+    });
+
+    const out = { ...registration, groups: usersToGroups };
+    return res.json({ data: out });
   };
 }

--- a/src/services/usersToGroups.spec.ts
+++ b/src/services/usersToGroups.spec.ts
@@ -1,7 +1,7 @@
 import { PostgresJsDatabase, drizzle } from 'drizzle-orm/postgres-js';
 import * as db from '../db';
 import { overwriteUsersToGroups } from './usersToGroups';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { createDbPool } from '../utils/createDbPool';
 import postgres from 'postgres';
 
@@ -51,6 +51,17 @@ describe('service: usersToGroups', function () {
   });
 
   afterAll(async function () {
+    // delete user to groups
+    await dbPool.delete(db.usersToGroups).where(eq(db.usersToGroups.userId, user?.id ?? ''));
+    // delete groups
+    await dbPool.delete(db.groups).where(
+      inArray(
+        db.groups.id,
+        defaultGroups.map((g) => g.id),
+      ),
+    );
+    // delete user
+    await dbPool.delete(db.users).where(eq(db.users.id, user?.id ?? ''));
     await dbConnection.end();
   });
 });

--- a/src/services/usersToGroups.spec.ts
+++ b/src/services/usersToGroups.spec.ts
@@ -7,7 +7,6 @@ import postgres from 'postgres';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 
-// Test create group memberships
 describe('service: usersToGroups', function () {
   let dbPool: PostgresJsDatabase<typeof db>;
   let dbConnection: postgres.Sql<{}>;

--- a/src/services/usersToGroups.spec.ts
+++ b/src/services/usersToGroups.spec.ts
@@ -1,0 +1,57 @@
+import { PostgresJsDatabase, drizzle } from 'drizzle-orm/postgres-js';
+import * as db from '../db';
+import { overwriteUsersToGroups } from './usersToGroups';
+import { eq } from 'drizzle-orm';
+import { createDbPool } from '../utils/createDbPool';
+import postgres from 'postgres';
+
+const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
+
+// Test create group memberships
+describe('service: usersToGroups', function () {
+  let dbPool: PostgresJsDatabase<typeof db>;
+  let dbConnection: postgres.Sql<{}>;
+  let user: db.User | undefined;
+  let defaultGroups: db.Group[];
+  beforeAll(async function () {
+    const initDb = createDbPool(DB_CONNECTION_URL, { max: 1 });
+    dbPool = initDb.dbPool;
+    dbConnection = initDb.connection;
+    user = (await dbPool.insert(db.users).values({}).returning())[0];
+
+    // creates initial groups
+    defaultGroups = await dbPool
+      .insert(db.groups)
+      .values([
+        {
+          name: 'blue',
+        },
+        {
+          name: 'red',
+        },
+      ])
+      .returning();
+  });
+
+  test('can save initial groups', async function () {
+    await overwriteUsersToGroups(dbPool, user?.id ?? '', [defaultGroups[0]?.id ?? '']);
+    const group = await dbPool.query.usersToGroups.findFirst({
+      where: eq(db.usersToGroups.groupId, defaultGroups[0]?.id ?? ''),
+    });
+    expect(group?.userId).toBeDefined;
+    expect(group?.userId).toBe(user?.id);
+  });
+
+  test('can overwrite old groups', async function () {
+    await overwriteUsersToGroups(dbPool, user?.id ?? '', [defaultGroups[1]?.id ?? '']);
+    const group = await dbPool.query.usersToGroups.findFirst({
+      where: eq(db.usersToGroups.groupId, defaultGroups[1]?.id ?? ''),
+    });
+    expect(group?.userId).toBeDefined;
+    expect(group?.userId).toBe(user?.id);
+  });
+
+  afterAll(async function () {
+    await dbConnection.end();
+  });
+});

--- a/src/services/usersToGroups.ts
+++ b/src/services/usersToGroups.ts
@@ -1,0 +1,24 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as db from '../db';
+import { eq } from 'drizzle-orm';
+
+export async function overwriteUsersToGroups(
+  dbPool: PostgresJsDatabase<typeof db>,
+  userId: string,
+  newGroupIds: string[],
+): Promise<db.UsersToGroups[] | null> {
+  // delete all groups that previously existed
+  try {
+    await dbPool.delete(db.usersToGroups).where(eq(db.usersToGroups.userId, userId));
+  } catch (e) {
+    console.log('error deleting user groups ' + JSON.stringify(e));
+    return null;
+  }
+  // save the new ones
+  const newUsersToGroups = await dbPool
+    .insert(db.usersToGroups)
+    .values(newGroupIds.map((groupId) => ({ groupId, userId })))
+    .returning();
+  // return new user groups
+  return newUsersToGroups;
+}

--- a/src/types/registration.ts
+++ b/src/types/registration.ts
@@ -1,4 +1,9 @@
 import { createInsertSchema } from 'drizzle-zod';
 import { registrations } from '../db/registrations';
+import { z } from 'zod';
 
-export const insertRegistrationSchema = createInsertSchema(registrations);
+const groupIds = z.string().array();
+
+export const insertRegistrationSchema = createInsertSchema(registrations).extend({
+  groupIds,
+});

--- a/src/utils/createDbPool.ts
+++ b/src/utils/createDbPool.ts
@@ -1,0 +1,25 @@
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import pgConnectionString from 'pg-connection-string';
+import { z } from 'zod';
+import * as db from '../db';
+
+/**
+ * creates a postgres database pool connection from connection string
+ */
+export function createDbPool(
+  dbConnectionUrl: string,
+  overwriteOptions: postgres.Options<{}> | undefined,
+) {
+  const connectionConfig = pgConnectionString.parse(dbConnectionUrl);
+  const defaultOptions: postgres.Options<{}> | undefined = {
+    host: connectionConfig.host ?? undefined,
+    port: connectionConfig.port ? parseInt(connectionConfig.port) : undefined,
+    user: connectionConfig.user,
+    password: connectionConfig.password,
+    database: connectionConfig.database ?? undefined,
+    ssl: connectionConfig.ssl as undefined,
+  };
+  const sql = postgres({ ...defaultOptions, ...overwriteOptions });
+  return { dbPool: drizzle(sql, { schema: db }), connection: sql };
+}


### PR DESCRIPTION
## overview
- adds unit testing for services expecting `postgresql://postgres:secretpassword@localhost:5432` to be available
- refactored following logic to smaller functions: createDbPool and upsertRegistration
- introduces overwriteUsersToGroups and tests for function