### PR TITLE
Connect database to plural score 

### DIFF
--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -29,24 +29,34 @@ describe('createGroupMemberships', () => {
   });
 });
 
-/*
 // test common group
 describe('commonGroup', () => {
   test('should return true if participants share a common group', () => {
-    const groupMemberships: number[][] = [[0, 2], [0, 1], [1, 2], [1]];
+    const groupMemberships: Record<string, string[]> = {
+      user0: ['group0', 'group2'],
+      user1: ['group0', 'group1'],
+      user2: ['group1', 'group2'],
+      user3: ['group1'],
+    };
 
-    const result = pluralVoting.commonGroup(0, 1, groupMemberships);
+    const result = pluralVoting.commonGroup('user0', 'user1', groupMemberships);
     expect(result).toBe(true);
   });
 
   test('should return false if participants do not share a common group', () => {
-    const groupMemberships: number[][] = [[0, 2], [0, 1], [1, 2], [1]];
+    const groupMemberships: Record<string, string[]> = {
+      user0: ['group0', 'group2'],
+      user1: ['group0', 'group1'],
+      user2: ['group1', 'group2'],
+      user3: ['group1'],
+    };
 
-    const result = pluralVoting.commonGroup(0, 3, groupMemberships);
+    const result = pluralVoting.commonGroup('user0', 'user3', groupMemberships);
     expect(result).toBe(false);
   });
 });
 
+/*
 // test vote attenuation
 describe('K function', () => {
   test('should not attenuate votes of i if i is not in group and does not have any relations with members of the group', () => {

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -115,22 +115,8 @@ describe('clusterMatch', () => {
   });
 
   test('noting but prints result', () => {
-    // Example usage:
-    const exampleGroups: Record<string, string[]> = {
-      group0: ['user0', 'user1'],
-      group1: ['user1', 'user2', 'user3'],
-      group2: ['user0', 'user2'],
-    };
-
-    const exampleContributions: Record<string, number> = {
-      user0: 1,
-      user1: 2,
-      user2: 3,
-      user3: 4,
-    };
-
-    const pluralityScore = new PluralVoting(exampleGroups, exampleContributions);
-    pluralityScore.pluralScoreCalculation(exampleGroups, exampleContributions);
+    const score = pluralVoting.pluralScoreCalculation();
+    console.log('Plurality Score:', score);
     expect(true).toBe(true);
   });
 });

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -56,56 +56,51 @@ describe('commonGroup', () => {
   });
 });
 
-/*
 // test vote attenuation
 describe('K function', () => {
-  test('should not attenuate votes of i if i is not in group and does not have any relations with members of the group', () => {
-    const i = 0;
-    const group = [1];
-    const groupMemberships = [[0], [1, 2]];
-    const contributions = [4, 9, 16];
+  test('should not attenuate votes of agent if agent is not in group and does not have any relations with members of the group', () => {
+    const agent = 'user0';
+    const otherGroup = ['user1'];
+    const groupMemberships = { user0: ['group0'], user1: ['group1', 'group2'] };
+    const contributions = { user0: 4, user1: 9 };
 
-    const result = pluralVoting.K(i, group, groupMemberships, contributions);
+    const result = pluralVoting.K(agent, otherGroup, groupMemberships, contributions);
     expect(result).toEqual(4);
   });
 
-  test('should attenuate votes of i if i has a shared group membership with another member of the group even if i is not in the group', () => {
-    const i = 0;
-    const group = [1];
-    const groupMemberships = [
-      [0, 1],
-      [1, 2],
-    ];
-    const contributions = [4, 9, 16];
+  test('should attenuate votes of agent if agent has a shared group membership with another member of the group even if agent is not in the group', () => {
+    const agent = 'user0';
+    const otherGroup = ['user1'];
+    const groupMemberships = { user0: ['group0', 'group1'], user1: ['group1', 'group2'] };
+    const contributions = { user0: 4, user1: 9 };
 
-    const result = pluralVoting.K(i, group, groupMemberships, contributions);
+    const result = pluralVoting.K(agent, otherGroup, groupMemberships, contributions);
     expect(result).toEqual(2);
   });
 
-  test('should attenuate votes of i solely because i is in the other group himself', () => {
-    const i = 0;
-    const group = [1];
-    const groupMemberships = [[0], [0, 1, 2]];
-    const contributions = [4, 9, 16];
+  test('should attenuate votes of agent solely because agent is in the other group himself', () => {
+    // theoretical test case, because if agent is in group h the agent
+    // automatically shares a group (i.e. group h) with all its members
+    const agent = 'user0';
+    const otherGroup = ['user0', 'user1'];
+    const groupMemberships = { user0: ['group0'], user1: ['group1', 'group2'] };
+    const contributions = { user0: 4, user1: 9 };
 
-    const result = pluralVoting.K(i, group, groupMemberships, contributions);
+    const result = pluralVoting.K(agent, otherGroup, groupMemberships, contributions);
     expect(result).toEqual(2);
   });
 
-  test('should attenuate votes of i if both conditions above that lead to attenuation are satisfied', () => {
-    const i = 0;
-    const group = [1];
-    const groupMemberships = [
-      [0, 1],
-      [0, 1, 2],
-    ];
-    const contributions = [4, 9, 16];
+  test('should attenuate votes of agent if both conditions above that lead to attenuation are satisfied', () => {
+    const agent = 'user0';
+    const otherGroup = ['user0', 'user1'];
+    const groupMemberships = { user0: ['group0', 'group1'], user1: ['group1', 'group2'] };
+    const contributions = { user0: 4, user1: 9 };
 
-    const result = pluralVoting.K(i, group, groupMemberships, contributions);
+    const result = pluralVoting.K(agent, otherGroup, groupMemberships, contributions);
     expect(result).toEqual(2);
   });
 });
-
+/*
 // Test connection oriented cluster match
 describe('clusterMatch', () => {
   test('calculates plurality score according to connection oriented cluster match', () => {

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -100,12 +100,12 @@ describe('K function', () => {
     expect(result).toEqual(2);
   });
 });
-/*
+
 // Test connection oriented cluster match
 describe('clusterMatch', () => {
   test('calculates plurality score according to connection oriented cluster match', () => {
-    const groups: number[][] = [[0], [1]];
-    const contributions: number[] = [4, 4];
+    const groups: Record<string, string[]> = { group0: ['user0'], group1: ['user1'] };
+    const contributions: Record<string, number> = { user0: 4, user1: 4 };
 
     // Expected result
     const expectedScore = 4;
@@ -116,16 +116,21 @@ describe('clusterMatch', () => {
 
   test('noting but prints result', () => {
     // Example usage:
-    const exampleGroups: number[][] = [
-      [0, 1],
-      [1, 2, 3],
-      [0, 2],
-    ];
-    const exampleContributions: number[] = [1, 2, 3, 4];
+    const exampleGroups: Record<string, string[]> = {
+      group0: ['user0', 'user1'],
+      group1: ['user1', 'user2', 'user3'],
+      group2: ['user0', 'user2'],
+    };
+
+    const exampleContributions: Record<string, number> = {
+      user0: 1,
+      user1: 2,
+      user2: 3,
+      user3: 4,
+    };
 
     const pluralityScore = new PluralVoting(exampleGroups, exampleContributions);
     pluralityScore.pluralScoreCalculation(exampleGroups, exampleContributions);
     expect(true).toBe(true);
   });
 });
-*/

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -96,7 +96,7 @@ describe('clusterMatch', () => {
     expect(result).toEqual(expectedScore);
   });
 
-  test('', () => {
+  test('noting but prints result', () => {
     // Example usage:
     const exampleGroups: number[][] = [
       [0, 1],

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -1,22 +1,35 @@
 import { PluralVoting } from './plural_voting';
 
 // Define instance outside the tests
-const groups = [
-  [0, 1],
-  [1, 2, 3],
-  [0, 2],
-];
-const contributions: number[] = [1, 2, 3, 4];
+const groups: Record<string, string[]> = {
+  group0: ['user0', 'user1'],
+  group1: ['user1', 'user2', 'user3'],
+  group2: ['user0', 'user2'],
+};
+
+const contributions: Record<string, number> = {
+  user0: 1,
+  user1: 2,
+  user2: 3,
+  user3: 4,
+};
+
 const pluralVoting = new PluralVoting(groups, contributions);
 
 // Test create group memberships
 describe('createGroupMemberships', () => {
   test('creates group memberships correctly', () => {
     const result = pluralVoting.createGroupMemberships(groups);
-    expect(result).toEqual([[0, 2], [0, 1], [1, 2], [1]]);
+    expect(result).toEqual({
+      user0: ['group0', 'group2'],
+      user1: ['group0', 'group1'],
+      user2: ['group1', 'group2'],
+      user3: ['group1'],
+    });
   });
 });
 
+/*
 // test common group
 describe('commonGroup', () => {
   test('should return true if participants share a common group', () => {
@@ -110,3 +123,4 @@ describe('clusterMatch', () => {
     expect(true).toBe(true);
   });
 });
+*/

--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -114,6 +114,17 @@ describe('clusterMatch', () => {
     expect(result).toEqual(expectedScore);
   });
 
+  test('calculates plurality score even if only one group is available', () => {
+    const groups: Record<string, string[]> = { group0: ['user0', 'user1'] };
+    const contributions: Record<string, number> = { user0: 6, user1: 3 };
+
+    // Expected result is the square root of the sum of contributions
+    const expectedScore = 3;
+
+    const result = pluralVoting.clusterMatch(groups, contributions);
+    expect(result).toEqual(expectedScore);
+  });
+
   test('noting but prints result', () => {
     const score = pluralVoting.pluralScoreCalculation();
     console.log('Plurality Score:', score);

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -46,30 +46,33 @@ class PluralVoting {
     throw new Error(`Group memberships for agent ${agent1} or ${agent2} are undefined.`);
   }
 
-  /*
   public K(
-    i: number,
-    group: number[],
-    groupMemberships: number[][],
-    contributions: number[],
+    agent: string,
+    otherGroup: string[],
+    groupMemberships: Record<string, string[]>,
+    contributions: Record<string, number>,
   ): number {
-    // Define the weighting function that attenuates the votes of agent i given different group memberships.
-    // :param: i: denotes a participant.
-    // :param: group: group denotes the other group.
+    // Define the weighting function that attenuates the votes of an agent given different group memberships.
+    // :param: agent: denotes a participant.
+    // :param: otherGroup: denotes a group.
     // :returns: attenuated number of votes for a given project.
 
-    const contributionsI = contributions[i];
+    const contributions_agent = contributions[agent];
 
-    if (contributionsI !== undefined) {
-      if (group.includes(i) || group.some((j) => this.commonGroup(i, j, groupMemberships))) {
-        return Math.sqrt(contributionsI);
+    if (contributions_agent !== undefined) {
+      if (
+        otherGroup.includes(agent) ||
+        otherGroup.some((otherAgent) => this.commonGroup(agent, otherAgent, groupMemberships))
+      ) {
+        return Math.sqrt(contributions_agent);
       }
-      return contributionsI;
+      return contributions_agent;
     }
 
-    throw new Error(`Contributions for agent ${i} are undefined.`);
+    throw new Error(`Contributions for agent ${agent} are undefined.`);
   }
 
+  /*
   public clusterMatch(groups: number[][], contributions: number[]): number {
     // Calculates the plurality score according to connection-oriented cluster match.
     // :param: groups (list of lists): a list denotes the group and contains its members.

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -25,24 +25,28 @@ class PluralVoting {
 
     return memberships;
   }
-  /*
-  public commonGroup(i: number, j: number, groupMemberships: number[][]): boolean {
-    // Define an identifier indicating whether two participants share the same group or whether any
-    // other member of the group of the second agent shares a group with the first agent.
-    // :param: i: agent_i denotes a participant not equal to a participant called agent_j.
-    // :param: j: agent_j denotes a participant not equal to a participant called agent_i.
-    // :returns (bool): returns true if two participants share a common group and false otherwise.
 
-    const membershipsI = groupMemberships[i];
-    const membershipsJ = groupMemberships[j];
+  public commonGroup(
+    agent1: string,
+    agent2: string,
+    groupMemberships: Record<string, string[]>,
+  ): boolean {
+    // Define an identifier indicating whether two participants share the same group.
+    // :param: agent1: agent1 denotes a participant not equal to a participant called agent2.
+    // :param: agent2: agent2 denotes a participant not equal to a participant called agent1.
+    // :returns (bool): returns true if two participants share groups memberships according to the definition and false otherwise.
 
-    if (membershipsI && membershipsJ) {
-      return membershipsI.some((group) => membershipsJ.includes(group));
+    const memberships_agent1 = groupMemberships[agent1];
+    const memberships_agent2 = groupMemberships[agent2];
+
+    if (memberships_agent1 && memberships_agent2) {
+      return memberships_agent1.some((group) => memberships_agent2.includes(group));
     }
 
-    throw new Error(`Group memberships for agent ${i} or ${j} are undefined.`);
+    throw new Error(`Group memberships for agent ${agent1} or ${agent2} are undefined.`);
   }
 
+  /*
   public K(
     i: number,
     group: number[],

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -1,4 +1,4 @@
-class PluralVoting {
+export class PluralVoting {
   // Class that contains the functions to calculate a plural score for each project proposal.
   // :param: groups (dict): a dictionary of groups as keys where the values are arrays of group members (users).
   // :param: contributions (dict): the keys identify users and the values denote the votes for a given project proposal.
@@ -72,14 +72,16 @@ class PluralVoting {
     throw new Error(`Contributions for agent ${agent} are undefined.`);
   }
 
-  /*
-  public clusterMatch(groups: number[][], contributions: number[]): number {
+  public clusterMatch(
+    groups: Record<string, string[]>,
+    contributions: Record<string, number>,
+  ): number {
     // Calculates the plurality score according to connection-oriented cluster match.
-    // :param: groups (list of lists): a list denotes the group and contains its members.
-    // :param: contributions (list): number of participant's votes for a given project proposal.
-    // :returns: plurality score
+    // :param: groups (dict): a dictionary of groups as keys where the values are arrays of group members (users).
+    // :param: contributions (dict): the keys identify users and the values denote the votes for a given project proposal.
+    // :returns: number: plurality score
 
-    const groupMemberships: number[][] = this.createGroupMemberships(groups);
+    const groupMemberships: Record<string, string[]> = this.createGroupMemberships(groups);
 
     if (groupMemberships === undefined) {
       throw new Error('Group memberships are undefined.');
@@ -88,13 +90,13 @@ class PluralVoting {
     let result = 0;
 
     // Calculate the first term of connection-oriented cluster match
-    for (let g of groups) {
-      for (let i of g) {
-        const contributionsI = contributions[i];
-        const membershipsI = groupMemberships[i];
+    for (const [groupName, members] of Object.entries(groups)) {
+      for (const agent of members) {
+        const contributionsI = contributions[agent];
+        const membershipsI = groupMemberships[agent];
 
         if (contributionsI === undefined || membershipsI === undefined) {
-          throw new Error(`Contributions or group memberships for agent ${i} are undefined.`);
+          throw new Error(`Contributions or group memberships for agent ${agent} are undefined.`);
         }
 
         result += contributionsI / membershipsI.length;
@@ -102,33 +104,36 @@ class PluralVoting {
     }
 
     // Calculate the interaction term of connection-oriented cluster match
-    for (let g of groups) {
-      for (let h of groups) {
-        if (g === h) continue; // Only skip if the groups are the same group instance (but not if they contain the same content)
+    for (const [group1Name, group1] of Object.entries(groups)) {
+      for (const [group2Name, group2] of Object.entries(groups)) {
+        if (group1Name === group2Name) continue; // Only skip if the groups are the same group instance (but not if they contain the same content)
 
         let term1 = 0;
-        for (let i of g) {
-          const contributionsI = contributions[i];
-          const membershipsI = groupMemberships[i];
+        for (const agent of group1) {
+          const contributionsI = contributions[agent];
+          const membershipsI = groupMemberships[agent];
 
           if (contributionsI === undefined || membershipsI === undefined) {
-            throw new Error(`Contributions or group memberships for agent ${i} are undefined.`);
+            throw new Error(`Contributions or group memberships for agent ${agent} are undefined.`);
           }
 
-          term1 += this.K(i, h, groupMemberships, contributions) / membershipsI.length;
+          term1 += this.K(agent, group2, groupMemberships, contributions) / membershipsI.length;
         }
         term1 = Math.sqrt(term1);
 
         let term2 = 0;
-        for (let j of h) {
-          const contributionsJ = contributions[j];
-          const membershipsJ = groupMemberships[j];
+        for (const otherAgent of group2) {
+          const contributionsJ = contributions[otherAgent];
+          const membershipsJ = groupMemberships[otherAgent];
 
           if (contributionsJ === undefined || membershipsJ === undefined) {
-            throw new Error(`Contributions or group memberships for agent ${j} are undefined.`);
+            throw new Error(
+              `Contributions or group memberships for agent ${otherAgent} are undefined.`,
+            );
           }
 
-          term2 += this.K(j, g, groupMemberships, contributions) / membershipsJ.length;
+          term2 +=
+            this.K(otherAgent, group1, groupMemberships, contributions) / membershipsJ.length;
         }
         term2 = Math.sqrt(term2);
 
@@ -139,15 +144,14 @@ class PluralVoting {
     return Math.sqrt(result);
   }
 
-  public pluralScoreCalculation(groups: number[][], contributions: number[]): void {
+  public pluralScoreCalculation(
+    groups: Record<string, string[]>,
+    contributions: Record<string, number>,
+  ): void {
     const result: number = this.clusterMatch(groups, contributions);
     console.log('Plurality Score', result);
   }
-  */
 }
-
-// Export functions
-export { PluralVoting };
 
 // Example usage
 /*

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -144,12 +144,12 @@ export class PluralVoting {
     return Math.sqrt(result);
   }
 
-  public pluralScoreCalculation(
-    groups: Record<string, string[]>,
-    contributions: Record<string, number>,
-  ): void {
-    const result: number = this.clusterMatch(groups, contributions);
-    console.log('Plurality Score', result);
+  public pluralScoreCalculation() // groups: Record<string, string[]>,
+  // contributions: Record<string, number>,
+  : number {
+    const result: number = this.clusterMatch(this.groups, this.contributions);
+
+    return result;
   }
 }
 

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -13,23 +13,19 @@ class PluralVoting {
 
   public createGroupMemberships(groups: Record<string, string[]>): Record<string, string[]> {
     // Define group memberships for each participant.
-    // :param: groups (list of lists): a list denotes the group and contains its members.
-    // :returns (list of lists): returns a list of group memberships for each participant.
+    // :param: groups (dict): a dictionary of groups as keys where the values are arrays of group members (users).
+    // :returns (dict): returns a dict of group memberships (value) for each user (key).
     const memberships: Record<string, string[]> = {};
 
-    for (let i = 0; i < groups.length; i++) {
-      const currentGroup = groups[i];
-      if (Array.isArray(currentGroup)) {
-        for (let j of currentGroup) {
-          const currentMembership = memberships[j] as number[] | undefined;
-          memberships[j] = [...(currentMembership || []), i];
-        }
+    for (const [groupName, members] of Object.entries(groups)) {
+      for (const member of members) {
+        memberships[member] = [...(memberships[member] || []), groupName];
       }
     }
 
     return memberships;
   }
-
+  /*
   public commonGroup(i: number, j: number, groupMemberships: number[][]): boolean {
     // Define an identifier indicating whether two participants share the same group or whether any
     // other member of the group of the second agent shares a group with the first agent.
@@ -140,6 +136,7 @@ class PluralVoting {
     const result: number = this.clusterMatch(groups, contributions);
     console.log('Plurality Score', result);
   }
+  */
 }
 
 // Export functions

--- a/src/modules/plural_voting.ts
+++ b/src/modules/plural_voting.ts
@@ -1,21 +1,21 @@
 class PluralVoting {
   // Class that contains the functions to calculate a plural score for each project proposal.
-  // :param: groups (list of lists): a list denotes the group and contains its members.
-  // :param: contributions (list): number of participant's votes for a given project proposal.
+  // :param: groups (dict): a dictionary of groups as keys where the values are arrays of group members (users).
+  // :param: contributions (dict): the keys identify users and the values denote the votes for a given project proposal.
   // :returns: plurality score
-  public groups: number[][];
-  public contributions: number[];
+  public groups: Record<string, string[]>;
+  public contributions: Record<string, number>;
 
-  constructor(groups: number[][], contributions: number[]) {
+  constructor(groups: Record<string, string[]>, contributions: Record<string, number>) {
     this.groups = groups;
     this.contributions = contributions;
   }
 
-  public createGroupMemberships(groups: number[][]): number[][] {
+  public createGroupMemberships(groups: Record<string, string[]>): Record<string, string[]> {
     // Define group memberships for each participant.
     // :param: groups (list of lists): a list denotes the group and contains its members.
     // :returns (list of lists): returns a list of group memberships for each participant.
-    const memberships: number[][] = [];
+    const memberships: Record<string, string[]> = {};
 
     for (let i = 0; i < groups.length; i++) {
       const currentGroup = groups[i];
@@ -147,9 +147,25 @@ export { PluralVoting };
 
 // Example usage
 /*
-const exampleGroups: number[][] = [[0, 1], [1, 2, 3], [0, 2]];
-const exampleContributions: number[] = [1, 2, 3, 4];
+const groups: number[][] = [[0, 1], [1, 2, 3], [0, 2]];
+const contributions: number[] = [1, 2, 3, 4];
 
-const pluralityScore = new PluralVoting(exampleGroups, exampleContributions);
-pluralityScore.pluralScoreCalculation(exampleGroups, exampleContributions);
+const pluralityScore = new PluralVoting(groups, contributions);
+pluralityScore.pluralScoreCalculation(groups, contributions);
+
+const groups: Record<string, string[]> = {
+      group0: [user0, user1],
+      group1: [user1, user2, user3],
+      group2: [user0, user2],
+    };
+
+const contributions: Record<string, number> = {
+      user0: 1,
+      user1: 2,
+      user2: 3,
+      user3: 4,
+    };
+
+const pluralityScore = new PluralVoting(groups, contributions);
+pluralityScore.pluralScoreCalculation(groups, contributions);
 */

--- a/src/modules/quadratic_voting.ts
+++ b/src/modules/quadratic_voting.ts
@@ -28,7 +28,7 @@ export function quadraticVoting(votes: Record<string, number>): [Record<string, 
 
 /*
 // Example usage:
-const votes: VotesDictionary = {
+const votes: Record<string, number> = {
   "user1": 4,
   "user2": 9,
   "user3": 16,

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -52,8 +52,15 @@ export function saveVote(dbPool: PostgresJsDatabase<typeof db>) {
     // Query groupId and array of user ids associated with the group
     const groupArray = await dbPool.execute<{ groupId: string; userIds: string[] }>(
       sql.raw(`
+          WITH users AS (
+            SELECT user_id AS "userId" 
+            FROM votes 
+            WHERE option_id = '${body.data.optionId}'
+          )
+          
           SELECT group_id AS "groupId", json_agg(user_id) AS "userIds"
           FROM users_to_groups
+          WHERE user_id IN (SELECT "userId" FROM users)
           GROUP BY group_id
         `),
     );

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -49,7 +49,7 @@ export function saveVote(dbPool: PostgresJsDatabase<typeof db>) {
       {} as Record<string, number>,
     );
 
-    // Query groupId and array of user ids associated with the group
+    // Query groupId and array of user ids associated with a given optionId
     const groupArray = await dbPool.execute<{ groupId: string; userIds: string[] }>(
       sql.raw(`
           WITH users AS (


### PR DESCRIPTION
This PR connects the plurality score to the database in a similar fashion as in the pr connecting the quadratic score. To implement the query I had to refactor the `plural_voting` module to be able to take the following input:  

```
const groups: Record<string, string[]> = {
  group0: ['user0', 'user1'],
  group1: ['user1', 'user2', 'user3'],
  group2: ['user0', 'user2'],
};

const contributions: Record<string, number> = {
  user0: 1,
  user1: 2,
  user2: 3,
  user3: 4,
};
```