### PR TITLE
fix get votes per cycle params

### DIFF
--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -8,6 +8,6 @@ const router = express.Router();
 export function usersRouter({ dbPool }: { dbPool: PostgresJsDatabase<typeof db> }) {
   router.get('/', isLoggedIn(), getUser(dbPool));
   router.get('/:userId/registration', isLoggedIn(), getRegistration(dbPool));
-  router.get('/:userId/options/:optionId/votes', isLoggedIn(), getVotes(dbPool));
+  router.get('/:userId/cycles/:cycleId/votes', isLoggedIn(), getVotes(dbPool));
   return router;
 }

--- a/src/services/users.spec.ts
+++ b/src/services/users.spec.ts
@@ -4,7 +4,7 @@ import postgres from 'postgres';
 import * as db from '../db';
 import { createDbPool } from '../utils/db/createDbPool';
 import { runMigrations } from '../utils/db/runMigrations';
-import { getVoteForOptionByUser } from './users';
+import { getVotesForCycleByUser } from './users';
 
 const DB_CONNECTION_URL = 'postgresql://postgres:secretpassword@localhost:5432';
 
@@ -12,6 +12,7 @@ describe('service: users', function () {
   let dbPool: PostgresJsDatabase<typeof db>;
   let dbConnection: postgres.Sql<{}>;
   let user: db.User | undefined;
+  let otherUser: db.User | undefined;
   let cycle: db.Cycle | undefined;
   let forumQuestion: db.ForumQuestion | undefined;
   let questionOption: db.QuestionOption | undefined;
@@ -22,6 +23,7 @@ describe('service: users', function () {
     dbPool = initDb.dbPool;
     dbConnection = initDb.connection;
     user = (await dbPool.insert(db.users).values({}).returning())[0];
+    otherUser = (await dbPool.insert(db.users).values({}).returning())[0];
     cycle = (
       await dbPool
         .insert(db.cycles)
@@ -71,15 +73,39 @@ describe('service: users', function () {
       userId: user!.id,
     });
 
-    const vote = await getVoteForOptionByUser(dbPool, user!.id, questionOption!.id);
-
+    const votes = await getVotesForCycleByUser(dbPool, user!.id, cycle!.id);
     // expect the latest votes
-    expect(vote?.numOfVotes).toBe(10);
+    expect(votes[0]?.forumQuestions[0]?.questionOptions[0]?.votes[0]?.numOfVotes).toBe(10);
+  });
+
+  test('should not get votes for other user', async function () {
+    // create vote in db
+    await dbPool.insert(db.votes).values({
+      numOfVotes: 2,
+      optionId: questionOption!.id,
+      userId: otherUser!.id,
+    });
+    // create second interaction with option
+    await dbPool.insert(db.votes).values({
+      numOfVotes: 10,
+      optionId: questionOption!.id,
+      userId: otherUser!.id,
+    });
+
+    const votes = await getVotesForCycleByUser(dbPool, user!.id, cycle!.id);
+
+    // no votes have otherUser's id in array
+    expect(
+      votes[0]?.forumQuestions[0]?.questionOptions[0]?.votes.filter(
+        (vote) => vote.userId === otherUser?.id,
+      ).length,
+    ).toBe(0);
   });
 
   afterAll(async function () {
     // delete votes
     await dbPool.delete(db.votes).where(eq(db.votes.userId, user?.id ?? ''));
+    await dbPool.delete(db.votes).where(eq(db.votes.userId, otherUser?.id ?? ''));
     // delete option
     await dbPool
       .delete(db.questionOptions)
@@ -90,6 +116,7 @@ describe('service: users', function () {
     await dbPool.delete(db.cycles).where(eq(db.cycles.id, cycle?.id ?? ''));
     // delete user
     await dbPool.delete(db.users).where(eq(db.users.id, user?.id ?? ''));
+    await dbPool.delete(db.users).where(eq(db.users.id, otherUser?.id ?? ''));
     await dbConnection.end();
   });
 });

--- a/src/services/users.spec.ts
+++ b/src/services/users.spec.ts
@@ -75,7 +75,7 @@ describe('service: users', function () {
 
     const votes = await getVotesForCycleByUser(dbPool, user!.id, cycle!.id);
     // expect the latest votes
-    expect(votes[0]?.forumQuestions[0]?.questionOptions[0]?.votes[0]?.numOfVotes).toBe(10);
+    expect(votes[0]?.numOfVotes).toBe(10);
   });
 
   test('should not get votes for other user', async function () {
@@ -92,14 +92,11 @@ describe('service: users', function () {
       userId: otherUser!.id,
     });
 
+    // user 1 gets votes but it should not include otherUser votes
     const votes = await getVotesForCycleByUser(dbPool, user!.id, cycle!.id);
 
     // no votes have otherUser's id in array
-    expect(
-      votes[0]?.forumQuestions[0]?.questionOptions[0]?.votes.filter(
-        (vote) => vote.userId === otherUser?.id,
-      ).length,
-    ).toBe(0);
+    expect(votes.filter((vote) => vote.userId === otherUser?.id).length).toBe(0);
   });
 
   afterAll(async function () {

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -86,7 +86,6 @@ export function getVotes(dbPool: PostgresJsDatabase<typeof db>) {
       });
     }
 
-
     const votesRow = await getVotesForCycleByUser(dbPool, userId, cycleId);
 
     return res.json({ data: votesRow });

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -116,12 +116,10 @@ export async function getVotesForCycleByUser(
     where: eq(db.cycles.id, cycleId),
   });
 
-  const out = response
-    .map((cycle) =>
-      cycle.forumQuestions.map((question) =>
-        question.questionOptions.map((option) => option.votes),
-      ),
-    )
-    .flat(3);
+  const out = response.flatMap((cycle) =>
+    cycle.forumQuestions.flatMap((question) =>
+      question.questionOptions.flatMap((option) => option.votes),
+    ),
+  );
   return out;
 }

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -116,5 +116,12 @@ export async function getVotesForCycleByUser(
     where: eq(db.cycles.id, cycleId),
   });
 
-  return response;
+  const out = response
+    .map((cycle) =>
+      cycle.forumQuestions.map((question) =>
+        question.questionOptions.map((option) => option.votes),
+      ),
+    )
+    .flat(3);
+  return out;
 }

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -64,7 +64,7 @@ export function getRegistration(dbPool: PostgresJsDatabase<typeof db>) {
 export function getVotes(dbPool: PostgresJsDatabase<typeof db>) {
   return async function (req: Request, res: Response) {
     const sessionUserId = req.session.userId;
-    const optionId = req.params.optionId;
+    const cycleId = req.params.cycleId;
     const userId = req.params.userId;
     if (userId !== sessionUserId) {
       return res.status(400).json({
@@ -76,17 +76,17 @@ export function getVotes(dbPool: PostgresJsDatabase<typeof db>) {
       });
     }
 
-    if (!optionId) {
+    if (!cycleId) {
       return res.status(400).json({
         errors: [
           {
-            message: 'Expected optionId in query params',
+            message: 'Expected cycleId in query params',
           },
         ],
       });
     }
 
-    const votesRow = await getVotesForCycleByUser(dbPool, userId, optionId);
+    const votesRow = await getVotesForCycleByUser(dbPool, userId, cycleId);
 
     return res.json({ data: votesRow });
   };


### PR DESCRIPTION
overview
- fixes the getVotes endpoint expecting and optionId instead a cycleId
- simplifies getVotes response by only returning an array of votes and not parent objects 