### PR TITLE
Fix jest configuration 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,8 @@
 module.exports = {
-    transform: {
-        '^.+\\.tsx?$': 'ts-jest',
-    },
-    globals: {
-      'ts-jest': {
-        tsconfig: './tsconfig.json',
-      },
-    },
-    testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
-    testPathIgnorePatterns: ['node_modules'],
-    preset: 'ts-jest',
-  };
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: './tsconfig.json' }],
+  },
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
+  testPathIgnorePatterns: ['node_modules'],
+  preset: 'ts-jest',
+};


### PR DESCRIPTION
When running the tests we get the following warning:

```
> forum@1.0.0 test C:\Users\beneb\forum-backend
> jest

ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},

```

The warining is not a `bug` in the traditional sense that it prevents the test from running, however, it polluted the console output as the warning was shown for each test suit. 

In this PR I moved the ts-jest configuration from globals to the transform key to fix the problem. The transform key now has an object value where the key is the regex pattern for matching TypeScript files, and the value is an array specifying the transformer (ts-jest) and its options.