### PR TITLE
Fix bug when the array of votes is zero 

### DIFF
--- a/src/modules/plural_voting.test.ts
+++ b/src/modules/plural_voting.test.ts
@@ -125,6 +125,17 @@ describe('clusterMatch', () => {
     expect(result).toEqual(expectedScore);
   });
 
+  test('that the plurality score equals zero when everyone votes 0', () => {
+    const groups: Record<string, string[]> = { group0: ['user0'], group1: ['user1'] };
+    const contributions: Record<string, number> = { user0: 0, user1: 0 };
+
+    // Expected result equals zero if everyone votes zero
+    const expectedScore = 0;
+
+    const result = pluralVoting.clusterMatch(groups, contributions);
+    expect(result).toEqual(expectedScore);
+  });
+
   test('noting but prints result', () => {
     const score = pluralVoting.pluralScoreCalculation();
     console.log('Plurality Score:', score);

--- a/src/services/votes.ts
+++ b/src/services/votes.ts
@@ -37,14 +37,18 @@ export function saveVote(dbPool: PostgresJsDatabase<typeof db>) {
             WHERE option_id = '${body.data.optionId}'
           ) AS ranked 
           WHERE row_num = 1
-          AND num_of_votes >= 1 
         `),
     );
+
+    // Check if there is at least one value greater than 0 in voteArray
+    const hasNonZeroValue = voteArray.some((vote) => vote.numOfVotes > 0);
 
     // Extract the dictionary of numOfVotes with userId as the key
     const numOfVotesDictionary = voteArray.reduce(
       (acc, vote) => {
-        acc[vote.userId] = vote.numOfVotes;
+        if (!hasNonZeroValue || vote.numOfVotes !== 0) {
+          acc[vote.userId] = vote.numOfVotes;
+        }
         return acc;
       },
       {} as Record<string, number>,


### PR DESCRIPTION
## Problem

When every voter makes the decision to revert their votes back to zero for a particular option the `VoteDictionary` in `votes.ts` is empty which crashes the application. 

## Solution

Changed the `VoteDictionary` function to filter out 0 values only if their is at least one positive value in the vote dictionary. However, if all values are zero it keeps all 0 values and the `VoteDisctionary` is defined. If all values are zero the plural score will be zero as expected.

## Example 

The condition that implements the solution is kind of hard to read. Therfore, here an example: 

```
const voteArray = [
  { userId: 'user1', numOfVotes: 0 },
  { userId: 'user2', numOfVotes: 3 },
  { userId: 'user3', numOfVotes: 0 },
];
```

Condtion: `if (!hasNonZeroValue || vote.numOfVotes !== 0)`

First Entry (user1):

- hasNonZeroValue is true because there is at least one value greater than 0 (numOfVotes of user2).
- !hasNonZeroValue is false.
- vote.numOfVotes !== 0 is false because numOfVotes is 0.
- The condition evaluates to false || false, which is false.
- Therefore, the key-value pair { userId: 'user1', numOfVotes: 0 } is not included in numOfVotesDictionary.

Second Entry (user2):

- hasNonZeroValue is still true.
- !hasNonZeroValue is false.
- vote.numOfVotes !== 0 is true because numOfVotes is 3.
- The condition evaluates to false || true, which is true.
- Therefore, the key-value pair { userId: 'user2', numOfVotes: 3 } is included in numOfVotesDictionary.

Third Entry (user3):

- hasNonZeroValue is still true.
- !hasNonZeroValue is false.
- vote.numOfVotes !== 0 is false because numOfVotes is 0.
- The condition evaluates to false || false, which is false.
- Therefore, the key-value pair { userId: 'user3', numOfVotes: 0 } is not included in numOfVotesDictionary.

In summary, this condition excludes entries with numOfVotes equal to 0 when there is at least one non-zero value in voteArray. It includes entries with numOfVotes equal to 0 only when all values in voteArray are 0.



