### PR TITLE
Fix post deployment workflows

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -32,6 +32,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run Version Bump Script
         run: scripts/workflows/bump-version.sh "${{ join(github.event.pull_request.labels.*.name, ' ') }}"
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,6 +32,9 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run Version Bump Script
         run: scripts/workflows/bump-version.sh "${{ join(github.event.pull_request.labels.*.name, ' ') }}"
 


### PR DESCRIPTION
closes https://github.com/lexicongovernance/forum-backend/issues/145

## overview
on our deployment jobs we do not install dependencies as they are not needed but it seems like this causes a bug https://github.com/actions/setup-node/issues/801

this should remove the error 